### PR TITLE
Href package returns na character

### DIFF
--- a/R/link.R
+++ b/R/link.R
@@ -263,7 +263,7 @@ href_article <- function(article, package = NULL) {
 href_package <- function(package) {
   urls <- package_urls(package)
   if (length(urls) == 0) {
-    NA
+    NA_character_
   } else {
     urls[[1]]
   }

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -186,3 +186,7 @@ test_that("autolink generates HTML if linkable", {
   )
   expect_equal(autolink("1 +"), NA_character_)
 })
+
+test_that("href_package can handle non-existing packages", {
+  expect_equal(href_package("NotAPackage"), NA_character_)
+})


### PR DESCRIPTION
I noticed that if my markdown contained a non-existing package attach, like `library(NotAPackage)`, then hugodown would error. I traced it down to a line of code within hugodown:

```
vapply(code, downlit::autolink_url, character(1))
```

If `code == "library(dplyr)"` then `downlist::autolink_url` will return a character URL. In the case that `code == "library(NotAPackage)"` then `downlist::autolink_url` will return `NA`. This is of type `logical`, which does not match `character(1)`, and so the call errors.

The minor change here ensures that an NA of the correct type is returned by the `href_package` function. I've also included the unit test I added to track my target.