### PR TITLE
Remove extra newline in <pre> output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # downlit (development version)
 
-* Trailing newlines are no longer stripped from URLs (#45, @krlmlr).
+* Trailing `/` are no longer stripped from URLs (#45, @krlmlr).
 
 * Removed extra newline in `<pre>` output (#42, @krlmlr).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # downlit (development version)
 
+* Trailing newlines are no longer stripped from URLs (#45, @krlmlr).
+
+* Removed extra newline in `<pre>` output (#42, @krlmlr).
+
 # downlit 0.1.0
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -60,7 +60,7 @@ highlight <- function(text, classes = classes_chroma(), pre_class = NULL) {
 
   paste0(
     "<pre class='", paste0(pre_class, collapse = " "), "'>\n",
-    out, "\n",
+    out,
     "</pre>"
   )
 }

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -78,7 +78,6 @@ package_urls <- function(package) {
 parse_urls <- function(x) {
   urls <- trimws(strsplit(trimws(x), "[,\\s]+", perl = TRUE)[[1]])
   urls <- urls[grepl("^http", urls)]
-  urls <- sub("/$", "", urls)
 
   sub_special_cases(urls)
 }

--- a/tests/testthat/test-downlit-html.txt
+++ b/tests/testthat/test-downlit-html.txt
@@ -9,7 +9,6 @@
 <span class="co"># This is a comment</span>
 
 <span class="kw">stats</span>::<span class="fu"><a href="https://rdrr.io/r/stats/median.html">median</a></span>()
-
 </pre>
 <p><code><a href="https://rdrr.io/r/stats/median.html">stats::median()</a></code></p>
 

--- a/tests/testthat/test-downlit-md-v20.txt
+++ b/tests/testthat/test-downlit-md-v20.txt
@@ -4,7 +4,6 @@
 > cat(downlit_md_string("```\nbase::t(1)\n```"))
 <pre class='chroma'>
 <span class='k'>base</span>::<span class='nf'><a href='https://rdrr.io/r/base/t.html'>t</a></span>(<span class='m'>1</span>)
-
 </pre>
 
 > cat(downlit_md_string(brio::read_lines(test_path("markdown-table.md"))))

--- a/tests/testthat/test-downlit-md-v21.txt
+++ b/tests/testthat/test-downlit-md-v21.txt
@@ -3,8 +3,7 @@
 
 > cat(downlit_md_string("```\nbase::t(1)\n```"))
 <pre class='chroma'>
-<span class='k'>base</span>::<span class='nf'><a href='https://rdrr.io/r/base/t.html'>t</a></span>(<span class='m'>1</span>)
-</pre>
+<span class='k'>base</span>::<span class='nf'><a href='https://rdrr.io/r/base/t.html'>t</a></span>(<span class='m'>1</span>)</pre>
 
 > cat(downlit_md_string(brio::read_lines(test_path("markdown-table.md"))))
 Table: Caption [`base::t`](https://rdrr.io/r/base/t.html)

--- a/tests/testthat/test-highlight.txt
+++ b/tests/testthat/test-highlight.txt
@@ -10,7 +10,7 @@
 
 > # implicit package
 > cat(highlight("library(MASS)"))
-<span class='nf'><a href='https://rdrr.io/r/base/library.html'>library</a></span>(<span class='k'><a href='http://www.stats.ox.ac.uk/pub/MASS4'>MASS</a></span>)
+<span class='nf'><a href='https://rdrr.io/r/base/library.html'>library</a></span>(<span class='k'><a href='http://www.stats.ox.ac.uk/pub/MASS4/'>MASS</a></span>)
 
 > cat(highlight("addterm()"))
 <span class='nf'><a href='https://rdrr.io/pkg/MASS/man/addterm.html'>addterm</a></span>()

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -124,7 +124,7 @@ test_that("library() linked to package reference", {
 
   expect_equal(href_expr_(library()), NA_character_)
   expect_equal(href_expr_(library(rlang)), "http://rlang.r-lib.org")
-  expect_equal(href_expr_(library(MASS)), "http://www.stats.ox.ac.uk/pub/MASS4")
+  expect_equal(href_expr_(library(MASS)), "http://www.stats.ox.ac.uk/pub/MASS4/")
 })
 
 # vignette ----------------------------------------------------------------

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -4,7 +4,7 @@ test_that("can extract urls for package", {
 
   expect_equal(package_urls("base"), character())
   expect_equal(package_urls("packagethatdoesn'texist"), character())
-  expect_equal(package_urls("MASS"), "http://www.stats.ox.ac.uk/pub/MASS4")
+  expect_equal(package_urls("MASS"), "http://www.stats.ox.ac.uk/pub/MASS4/")
 })
 
 test_that("handle common url formats", {


### PR DESCRIPTION
Example: https://github.com/r-prof/procmaps/commit/18ef3bebb5c67c73281c71551eadbd9198678ccc

Before: https://github.com/r-prof/procmaps/blob/f55c5769f30a43a5edc0eade12f5de4d6e89ba40/README.md

After: https://github.com/r-prof/procmaps/blob/18ef3bebb5c67c73281c71551eadbd9198678ccc/README.md