### PR TITLE
Set default URL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # downlit (development version)
 
+* Autolinking guesses reference and article urls for pkgdown sites that haven't
+  set url (@krlmlr, #44).
+
 * R6 classes are autolinked when a new object is created i.e. in 
   `r6_object$new()`, `r6_object` will link to the docs of `r6_object` if found
   (#59, @maelle)

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -44,6 +44,13 @@ remote_metadata_slow <- function(package) {
       if (has_name(yaml, "articles")) {
         yaml$articles <- unlist(yaml$articles)
       }
+      if (!has_name(yaml, "urls")) {
+        base_url <- dirname(url)
+        yaml$urls <- list(
+          reference = paste0(base_url, "/reference"),
+          article = paste0(base_url, "/articles")
+        )
+      }
       return(yaml)
     }
   }


### PR DESCRIPTION
if not available through the metadata, e.g. if the package doesn't set its `url:` in its `_pkgdown.yml`.