### PR TITLE
Keep trailing slash for URLs

### DIFF
--- a/R/metadata.R
+++ b/R/metadata.R
@@ -78,7 +78,6 @@ package_urls <- function(package) {
 parse_urls <- function(x) {
   urls <- trimws(strsplit(trimws(x), "[,\\s]+", perl = TRUE)[[1]])
   urls <- urls[grepl("^http", urls)]
-  urls <- sub("/$", "", urls)
 
   sub_special_cases(urls)
 }

--- a/tests/testthat/test-highlight.txt
+++ b/tests/testthat/test-highlight.txt
@@ -10,7 +10,7 @@
 
 > # implicit package
 > cat(highlight("library(MASS)"))
-<span class='nf'><a href='https://rdrr.io/r/base/library.html'>library</a></span>(<span class='k'><a href='http://www.stats.ox.ac.uk/pub/MASS4'>MASS</a></span>)
+<span class='nf'><a href='https://rdrr.io/r/base/library.html'>library</a></span>(<span class='k'><a href='http://www.stats.ox.ac.uk/pub/MASS4/'>MASS</a></span>)
 
 > cat(highlight("addterm()"))
 <span class='nf'><a href='https://rdrr.io/pkg/MASS/man/addterm.html'>addterm</a></span>()

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -124,7 +124,7 @@ test_that("library() linked to package reference", {
 
   expect_equal(href_expr_(library()), NA_character_)
   expect_equal(href_expr_(library(rlang)), "http://rlang.r-lib.org")
-  expect_equal(href_expr_(library(MASS)), "http://www.stats.ox.ac.uk/pub/MASS4")
+  expect_equal(href_expr_(library(MASS)), "http://www.stats.ox.ac.uk/pub/MASS4/")
 })
 
 # vignette ----------------------------------------------------------------

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -4,7 +4,7 @@ test_that("can extract urls for package", {
 
   expect_equal(package_urls("base"), character())
   expect_equal(package_urls("packagethatdoesn'texist"), character())
-  expect_equal(package_urls("MASS"), "http://www.stats.ox.ac.uk/pub/MASS4")
+  expect_equal(package_urls("MASS"), "http://www.stats.ox.ac.uk/pub/MASS4/")
 })
 
 test_that("handle common url formats", {


### PR DESCRIPTION
GitHub Pages started to redirect URLs of the form https://r-prof.github.io/procmaps to https://r-prof.github.io/procmaps/, this also has led to complaints from CRAN. In some cases (e.g. fresh deployment) the slashless version doesn't even work. I think we should honor the user's preference here.