### PR TITLE
allow for bookdown hacking?

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # downlit (development version)
 
+* Tweaked the XPath identifying R code blocks in `downlit_html_path()`, and 
+added a `classes` argument to `downlit_html_path()` (#53, @maelle, @cderv)
+
 * Trailing `/` are no longer stripped from URLs (#45, @krlmlr).
 
 * Removed extra newline in `<pre>` output (#42, @krlmlr).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # downlit (development version)
 
-* Tweaked the XPath identifying R code blocks in `downlit_html_path()`, and 
-added a `classes` argument to `downlit_html_path()` (#53, @maelle, @cderv)
+* `downlit_html_path()` has a more flexible XPath identifying R code blocks in , and 
+a `classes` argument (#53, @maelle, @cderv)
 
 * `classes_pandoc()` and `classes_chroma()` have been tweaked to generate
   better class names.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # downlit (development version)
 
-* `downlit_html_path()` has a more flexible XPath identifying R code blocks in , and 
+* `downlit_html_path()` has a more flexible XPath identifying R code blocks, and 
 a `classes` argument (#53, @maelle, @cderv)
 
 * `classes_pandoc()` and `classes_chroma()` have been tweaked to generate

--- a/R/downlit-html.R
+++ b/R/downlit-html.R
@@ -42,7 +42,7 @@ downlit_html_node <- function(x) {
   stopifnot(inherits(x, "xml_node"))
 
   # <pre class="sourceCode r">
-  xpath_block <- ".//pre[contains(@class, 'sourceCode r')]"
+  xpath_block <- ".//pre[contains(@class, 'sourceCode r')] | .//pre[@class='r']"
   tweak_children(x, xpath_block, highlight,
     pre_class = "downlit",
     classes = classes_pandoc(),

--- a/R/downlit-html.R
+++ b/R/downlit-html.R
@@ -13,6 +13,7 @@
 #' larger pipeline.
 #'
 #' @param in_path,out_path Input and output paths for HTML file
+#' @param classes Either `classes_pandoc()` or `classes_chroma()`
 #' @param x An `xml2::xml_node`
 #' @return `downlit_html_path()` invisibly returns `output_path`;
 #'   `downlit_html_node()` modifies `x` in place and returns nothing.
@@ -24,13 +25,13 @@
 #' # node is modified in place
 #' downlit_html_node(node)
 #' node
-downlit_html_path <- function(in_path, out_path) {
+downlit_html_path <- function(in_path, out_path, classes = classes_pandoc()) {
   if (!is_installed("xml2")) {
     abort("xml2 package required .html transformation")
   }
 
   html <- xml2::read_html(in_path, encoding = "UTF-8")
-  downlit_html_node(html)
+  downlit_html_node(html, classes = classes)
   xml2::write_html(html, out_path, format = FALSE)
 
   invisible(out_path)
@@ -38,14 +39,14 @@ downlit_html_path <- function(in_path, out_path) {
 
 #' @export
 #' @rdname downlit_html_path
-downlit_html_node <- function(x) {
+downlit_html_node <- function(x, classes) {
   stopifnot(inherits(x, "xml_node"))
 
   # <pre class="sourceCode r">
   xpath_block <- ".//pre[contains(@class, 'sourceCode r')] | .//pre[@class='r']"
   tweak_children(x, xpath_block, highlight,
     pre_class = "downlit",
-    classes = classes_pandoc(),
+    classes = classes,
     replace = "node"
   )
 

--- a/R/downlit-html.R
+++ b/R/downlit-html.R
@@ -13,7 +13,7 @@
 #' larger pipeline.
 #'
 #' @param in_path,out_path Input and output paths for HTML file
-#' @param classes Either `classes_pandoc()` or `classes_chroma()`
+#' @inheritParams highlight
 #' @param x An `xml2::xml_node`
 #' @return `downlit_html_path()` invisibly returns `output_path`;
 #'   `downlit_html_node()` modifies `x` in place and returns nothing.
@@ -39,7 +39,7 @@ downlit_html_path <- function(in_path, out_path, classes = classes_pandoc()) {
 
 #' @export
 #' @rdname downlit_html_path
-downlit_html_node <- function(x, classes) {
+downlit_html_node <- function(x, classes = classes_pandoc()) {
   stopifnot(inherits(x, "xml_node"))
 
   # <pre class="sourceCode r">

--- a/R/downlit-html.R
+++ b/R/downlit-html.R
@@ -43,6 +43,8 @@ downlit_html_node <- function(x, classes = classes_pandoc()) {
   stopifnot(inherits(x, "xml_node"))
 
   # <pre class="sourceCode r">
+  # and <pre class="r"> which is needed when knitting a bookdown gitbook
+  # where highlight is set to NULL
   xpath_block <- ".//pre[contains(@class, 'sourceCode r')] | .//pre[@class='r']"
   tweak_children(x, xpath_block, highlight,
     pre_class = "downlit",

--- a/man/downlit-package.Rd
+++ b/man/downlit-package.Rd
@@ -36,6 +36,7 @@ topics and articles/vignettes relative to the "current" file.
 \seealso{
 Useful links:
 \itemize{
+  \item \url{https://downlit.r-lib.org/}
   \item \url{https://github.com/r-lib/downlit}
   \item Report bugs at \url{https://github.com/r-lib/downlit/issues}
 }

--- a/man/downlit_html_path.Rd
+++ b/man/downlit_html_path.Rd
@@ -5,12 +5,14 @@
 \alias{downlit_html_node}
 \title{Syntax highlight and link an HTML page}
 \usage{
-downlit_html_path(in_path, out_path)
+downlit_html_path(in_path, out_path, classes = classes_pandoc())
 
-downlit_html_node(x)
+downlit_html_node(x, classes)
 }
 \arguments{
 \item{in_path, out_path}{Input and output paths for HTML file}
+
+\item{classes}{Either \code{classes_pandoc()} or \code{classes_chroma()}}
 
 \item{x}{An \code{xml2::xml_node}}
 }

--- a/man/downlit_html_path.Rd
+++ b/man/downlit_html_path.Rd
@@ -7,12 +7,15 @@
 \usage{
 downlit_html_path(in_path, out_path, classes = classes_pandoc())
 
-downlit_html_node(x, classes)
+downlit_html_node(x, classes = classes_pandoc())
 }
 \arguments{
 \item{in_path, out_path}{Input and output paths for HTML file}
 
-\item{classes}{Either \code{classes_pandoc()} or \code{classes_chroma()}}
+\item{classes}{A mapping between token names and CSS class names.
+Bundled \code{classes_pandoc()} and \code{classes_chroma()} provide mappings
+that (roughly) match Pandoc and chroma (used by hugo) classes so you
+can use existing themes.}
 
 \item{x}{An \code{xml2::xml_node}}
 }


### PR DESCRIPTION
alternative title: make `downlit_html_path()` more flexible. :-)

Context: I am working on a bookdown gitbook and was trying to find a hack to use downlit before it gets really supported (so patient :see_no_evil: ). I set bookdown's highlight parameter to `NULL` then I  use `downlit::downlit_html_path()` on all resulting HTML but the HTML nodes don't have the classes downlit would expect e.g.

```html
<pre class="r"><code>summary(cars)</code></pre>
<pre><code>##      speed           dist       
##  Min.   : 4.0   Min.   :  2.00  
##  1st Qu.:12.0   1st Qu.: 26.00  
##  Median :15.0   Median : 36.00  
##  Mean   :15.4   Mean   : 42.98  
##  3rd Qu.:19.0   3rd Qu.: 56.00  
##  Max.   :25.0   Max.   :120.00</code></pre>
```

Therefore I tweaked the xpath and now I only need to add a CSS and my gitbook will get autolinking _today_.

I reckon tweaking the package out of impatience is maybe not a good idea.