### PR TITLE
R6 instantiation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # downlit (development version)
 
+* R6 classes are autolinked when a new object is created i.e. in 
+  `r6_object$new()`, `r6_object` will link to the docs of `r6_object` if found
+  (#59, @maelle)
+
 * R6 methods are no longer autolinked as if they were functions of the same name (#54, @maelle).
 
 * `downlit_html_path()` has a more flexible XPath identifying R code blocks, and 

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -251,6 +251,17 @@ token_href <- function(token, text) {
   fun <- which(token %in% "SYMBOL_FUNCTION_CALL")
   fun <- setdiff(fun, ns_fun)
   fun <- fun[token[fun-1] != "'$'"]
+
+  # Highlight R6 instantiation
+
+  r6_new_call <- which(
+    text == "new" & token == "SYMBOL_FUNCTION_CALL"
+  )
+  r6_new_call <- r6_new_call[token[r6_new_call-1] == "'$'"]
+  r6_new_call <- r6_new_call[token[r6_new_call-3] == "SYMBOL"]
+
+  fun <- c(fun, r6_new_call - 3)
+
   href[fun] <- map_chr(text[fun], href_topic_local)
 
   # Highlight packages

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -253,12 +253,11 @@ token_href <- function(token, text) {
   fun <- fun[token[fun-1] != "'$'"]
 
   # Highlight R6 instantiation
-
   r6_new_call <- which(
     text == "new" & token == "SYMBOL_FUNCTION_CALL"
   )
-  r6_new_call <- r6_new_call[token[r6_new_call-1] == "'$'"]
-  r6_new_call <- r6_new_call[token[r6_new_call-3] == "SYMBOL"]
+  r6_new_call <- r6_new_call[token[r6_new_call - 1] == "'$'"]
+  r6_new_call <- r6_new_call[token[r6_new_call - 3] == "SYMBOL"]
 
   fun <- c(fun, r6_new_call - 3)
 

--- a/tests/testthat/test-highlight.R
+++ b/tests/testthat/test-highlight.R
@@ -70,3 +70,15 @@ test_that("R6 methods don't get linked", {
     "<span class='nv'>x</span><span class='o'>$</span><span class='nf'>get</span><span class='o'>(</span><span class='o'>)</span>"
   )
 })
+
+test_that("R6 instantiation gets linked", {
+  expect_equal(
+    highlight("mean$new()"),
+    "<span class='nv'><a href='https://rdrr.io/r/base/mean.html'>mean</a></span><span class='o'>$</span><span class='nf'>new</span><span class='o'>(</span><span class='o'>)</span>"
+  )
+  # But not new itself
+  expect_equal(
+    highlight("new()"),
+    "<span class='nf'>new</span><span class='o'>(</span><span class='o'>)</span>"
+  )
+})


### PR DESCRIPTION
I wanted to see how I could get

``` r
downlit::highlight("library(crul); HttpClient$new()")
#> [1] "<span class='kr'><a href='https://rdrr.io/r/base/library.html'>library</a></span><span class='o'>(</span><span class='nv'><a href='https://docs.ropensci.org/crul'>crul</a></span><span class='o'>)</span>; <span class='nv'><a href='https://docs.ropensci.org/crul/reference/HttpClient.html'>HttpClient</a></span><span class='o'>$</span><span class='nf'>new</span><span class='o'>(</span><span class='o'>)</span>"
```

<sup>Created on 2020-09-21 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

But 

* it might be adding too much complexity just for the special case of R6 instantiation;
* I can't test it without adding a dependency (or some sort of mocking);
* The usefulness of this is quite limited since downlit doesn't know what packages are really attached (compared to what knitr would know) so I'd probably be better off just namespacing (the reprex below works without any tweak). :sweat_smile:

``` r
downlit::highlight("crul::HttpClient$new()")
#> [1] "<span class='nf'>crul</span><span class='nf'>::</span><span class='nv'><a href='https://docs.ropensci.org/crul/reference/HttpClient.html'>HttpClient</a></span><span class='o'>$</span><span class='nf'>new</span><span class='o'>(</span><span class='o'>)</span>"
```

<sup>Created on 2020-09-21 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup> 