### PR TITLE
Suppress incomplete final line warning in `autolink_url`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # downlit (development version)
 
+* Now suppresses rare warning about incomplete final line in
+  `autolink_url("pkgname::foo")`. (@dmurdoch, pkgdown#1419).
+
 * Changes to better support for HTML widgets and rgl in pkgdown 
   (@dmurdoch, #78).
 

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -80,7 +80,9 @@ fetch_yaml <- function(url) {
     abort("Failed to download")
   }
 
-  yaml::read_yaml(path)
+  # This call may warn if the URL doesn't have a final LF;
+  # see pkgdown issue #1419
+  suppressWarnings(yaml::read_yaml(path))
 }
 
 # Helpers -----------------------------------------------------------------


### PR DESCRIPTION
If the file listed in the URL field of DESCRIPTION for `pkgname` had no final LF, `autolink_url("pkgname::foo")` would issue the incomplete final line warning.  This suppresses that warning, thereby fixing https://github.com/r-lib/pkgdown/issues/1419 .