### PR TITLE
special case for depends devtools::load_all-ed packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ Description: Syntax highlighting of R code, specifically designed
 License: MIT + file LICENSE
 Depends: R (>= 3.2.0)
 Imports: 
+    desc,
     brio,
     digest,
     evaluate,

--- a/R/packages.R
+++ b/R/packages.R
@@ -58,6 +58,7 @@ package_depends <- function(package) {
   names(meta$Depends)
 }
 
+# from https://github.com/r-lib/pkgdown/blob/8e0838e273462cec420dfa20f240c684a33425d9/R/utils.r#L62
 devtools_meta <- function(x) {
   ns <- .getNamespace(x)
   ns[[".__DEVTOOLS__"]]

--- a/R/packages.R
+++ b/R/packages.R
@@ -45,7 +45,20 @@ package_depends <- function(package) {
     return(character())
   }
 
+  if (!is.null(devtools_meta(package))) {
+    path_desc <- system.file("DESCRIPTION", package = "pkgdown")
+    deps <- desc::desc_get_deps(path_desc)
+    depends <- deps$package[deps$type == "Depends"]
+    depends <- depends[depends != "R"]
+    return(depends)
+  }
+
   path_meta <- system.file("Meta", "package.rds", package = package)
   meta <- readRDS(path_meta)
   names(meta$Depends)
+}
+
+devtools_meta <- function(x) {
+  ns <- .getNamespace(x)
+  ns[[".__DEVTOOLS__"]]
 }


### PR DESCRIPTION
Fix #92 

But it might be better to use `read.dcf()` / an entirely different approach?