### PR TITLE
Use `conditionMessage()` to render conditions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@
   output easier to read, and easier for package developers to style
   themselves.
 
+* Messages, warnings, and errors now retrieve their text using
+  `conditionMessage()`, which supports more advanced types of conditions
+  (@davidchall, #100).
+
 * The overall structure of the syntax highlighting has been overhauled.
   Now each line is wrapped in a `<span>` with class `r-in` (input code),
   `r-out` (output printed to console), `r-plot` (plots), `r-msg` (messages), 

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -120,13 +120,13 @@ replay_html.source <- function(x, ..., classes, highlight = FALSE) {
 
 #' @export
 replay_html.warning <- function(x, ...) {
-  message <- paste0(span("Warning: ", class = "warning"), escape_html(x$message))
+  message <- paste0(span("Warning: ", class = "warning"), escape_html(conditionMessage(x)))
   label_output(message, "r-wrn")
 }
 
 #' @export
 replay_html.message <- function(x, ...) {
-  message <- escape_html(paste0(gsub("\n$", "", x$message)))
+  message <- escape_html(paste0(gsub("\n$", "", conditionMessage(x))))
   label_output(message, "r-msg")
 }
 
@@ -137,7 +137,7 @@ replay_html.error <- function(x, ...) {
   } else {
     prefix <- paste0("Error in ", escape_html(paste0(deparse(x$call), collapse = "")))
   }
-  message <- paste0(span(prefix, class = "error"), " ", escape_html(x$message))
+  message <- paste0(span(prefix, class = "error"), " ", escape_html(conditionMessage(x)))
   label_output(message, "r-err")
 }
 


### PR DESCRIPTION
When following the [error constructor design pattern](https://design.tidyverse.org/err-constructor.html), we might have condition objects with an empty `message` field. Instead, their message is constructed via the `conditionMessage()` S3 method. Currently, such condition messages are omitted from the {downlit} output.