### PR TITLE
Ensure there are no double trailing slashes

### DIFF
--- a/R/metadata.R
+++ b/R/metadata.R
@@ -103,6 +103,7 @@ package_urls <- function(package) {
 parse_urls <- function(x) {
   urls <- trimws(strsplit(trimws(x), "[,\\s]+", perl = TRUE)[[1]])
   urls <- urls[grepl("^http", urls)]
+  urls <- sub("/$", "", urls)
 
   sub_special_cases(urls)
 }


### PR DESCRIPTION
At the moment e.g.

``` r
downlit::href_topic("bs_theme", "bslib")
#> [1] "https://rstudio.github.io/bslib//reference/bs_theme.html"
```

<sup>Created on 2021-06-18 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0.9000)</sup>