### PR TITLE
Don't link inside `<summary>` elements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # downlit (development version)
 
+* Functions in HTML `<summary>` elements are no longer autolinked 
+  (@gadenbuie, #105).
+
 ## Syntax highlighting
 
 * Messages, warnings, and errors now get a much more minimal style. 

--- a/R/downlit-html.R
+++ b/R/downlit-html.R
@@ -57,8 +57,8 @@ downlit_html_node <- function(x, classes = classes_pandoc()) {
     code = TRUE
   )
 
-  # Identify <code> containing only text (i.e. no children) that are
-  # are not descendants of a header or link
+  # Identify <code> containing only text (i.e. no children)
+  # that are not descendants of an element where links are undesirable
   bad_ancestor <- c("h1", "h2", "h3", "h4", "h5", "a", "summary")
   bad_ancestor <- paste0("ancestor::", bad_ancestor, collapse = "|")
   xpath_inline <- paste0(".//code[count(*) = 0 and not(", bad_ancestor, ")]")

--- a/R/downlit-html.R
+++ b/R/downlit-html.R
@@ -59,7 +59,7 @@ downlit_html_node <- function(x, classes = classes_pandoc()) {
 
   # Identify <code> containing only text (i.e. no children) that are
   # are not descendants of a header or link
-  bad_ancestor <- c("h1", "h2", "h3", "h4", "h5", "a")
+  bad_ancestor <- c("h1", "h2", "h3", "h4", "h5", "a", "summary")
   bad_ancestor <- paste0("ancestor::", bad_ancestor, collapse = "|")
   xpath_inline <- paste0(".//code[count(*) = 0 and not(", bad_ancestor, ")]")
 

--- a/tests/testthat/autolink.html
+++ b/tests/testthat/autolink.html
@@ -12,5 +12,6 @@ stats::median()
 <!-- Shouldn't get linked -->
 <h1><code>stats::median()</code></h1>
 <a><code>stats::median()</code></a>
+<details><summary><code>stats::median()</code></summary></details>
 
 </body></html>

--- a/tests/testthat/test-downlit-html.txt
+++ b/tests/testthat/test-downlit-html.txt
@@ -15,6 +15,6 @@
 <!-- Shouldn't get linked -->
 <h1><code>stats::median()</code></h1>
 <a><code>stats::median()</code></a>
-
+<details><summary><code>stats::median()</code></summary></details>
 </body></html>
 


### PR DESCRIPTION
Adds `summary` to the list of bad ancestors so that functions referenced in the disclosure `<summary>` element are not auto linked.

Technically, links _are_ [permitted content](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary) in the `<summary>` element, but they can be problematic. For example, they can interfere with users who click or tap the link when they intend to interact with the summary element to open or close the disclosure.