### PR TITLE
Check 'repos' repositories and CRAN for URL if package isn't installed

### DIFF
--- a/R/metadata.R
+++ b/R/metadata.R
@@ -171,12 +171,8 @@ check_repo_for_package_url <- function(repo, package) {
 }
 
 fetch_repo_packages_file <- function(repo) {
-  tmp_packages <- tempfile(fileext = ".rds")
-  on.exit(file.remove(tmp_packages))
 
-  if (suppressWarnings(utils::download.file(paste0(contrib.url(repo, type = "source"), "/PACKAGES.rds"), tmp_packages, quiet = TRUE))) {
-    abort("Failed to download")
-  }
+  available.packages(contrib.url(repo), fields = "URL")
 
   as.data.frame(readRDS(tmp_packages))
 }

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -7,6 +7,16 @@ test_that("can extract urls for package", {
   expect_equal(package_urls("MASS"), "http://www.stats.ox.ac.uk/pub/MASS4/")
 })
 
+test_that("can extract urls for uninstalled packages from CRAN", {
+  skip_on_cran()
+  skip_if(requireNamespace("BMRSr", quietly = TRUE))
+
+  # We're testing here that we can find URLs for packages that aren't installed
+  # I'm assuming that BMRSr isn't going to be installed (because why would it),
+  # but this might not be the best approach
+  expect_equal(package_urls("BMRSr"), "https://bmrsr.arawles.co.uk/")
+})
+
 test_that("handle common url formats", {
   ab <- c("https://a.com", "https://b.com")
 


### PR DESCRIPTION
This PR fixes #106.

Previously, packages needed to be installed for downlit to find the URL field. With this PR, downlit will go through 3 stages to try and find the URL, only proceeding to the next one if the previous one was unsuccessful:

1. Check for a local install and DESCRIPTION file
2. Check the user's 'repos' option (excluding any entries named CRAN) and check the PACKAGES file. This does mean that the PACKAGES file will need to include the URL field, which is not included by default, for this stage to be successful.
3. Check CRAN, using the `tools::CRAN_package_db()` function, which includes more meta-data than the `utils::available.packages()` function.

A test case has been written to check that URLS for packages that are not installed are found correctly, however it currently relies on the `BMRSr` package not being installed. Although it's unlikely that this package would ever be installed when these tests are being run as part of a CI process, it's not perfect.

Still left to consider is the possibility of allowing the user to register a custom function that could be used to find a PACKAGE url (see Issue for discussion).