### PR TITLE
allow call of library a la pkgdown

### DIFF
--- a/R/highlight.R
+++ b/R/highlight.R
@@ -299,6 +299,7 @@ token_href <- function(token, text) {
     to_end > 3
   )
   pkg <- lib_call + 3 # expr + '(' + STR_CONST
+  pkg <- pkg[nzchar(text[pkg])] # if e.g. library(a$pkg) then text[pkg] is ""
   href[pkg] <- map_chr(gsub("['\"]", "", text[pkg]), href_package)
 
   href

--- a/tests/testthat/_snaps/highlight.md
+++ b/tests/testthat/_snaps/highlight.md
@@ -14,3 +14,15 @@
 
     [1] "<span class='c'># <span style='color: #BB0000;'>hello</span></span>"
 
+# package loading is highlighted correctly if possible
+
+    [1] "<span class='kr'><a href='https://rdrr.io/r/base/library.html'>library</a></span><span class='o'>(</span><span class='s'>\"not.a.pkg\"</span><span class='o'>)</span>"
+
+---
+
+    [1] "<span class='kr'><a href='https://rdrr.io/r/base/library.html'>library</a></span><span class='o'>(</span><span class='nv'>not.a.pkg</span><span class='o'>)</span>"
+
+---
+
+    [1] "<span class='kr'><a href='https://rdrr.io/r/base/library.html'>library</a></span><span class='o'>(</span><span class='nv'>a_list</span><span class='o'>$</span><span class='nv'>pkg</span><span class='o'>)</span>"
+

--- a/tests/testthat/test-highlight.R
+++ b/tests/testthat/test-highlight.R
@@ -109,3 +109,11 @@ test_that("ansi escapes are converted to html", {
   expect_snapshot_output(highlight("# \033[31mhello\033[m"))
   expect_snapshot_output(highlight("# \u2029[31mhello\u2029[m"))
 })
+
+test_that("package loading is highlighted correctly if possible", {
+  expect_snapshot_output(highlight('library("not.a.pkg")'))
+  expect_snapshot_output(highlight('library(not.a.pkg)'))
+  expect_snapshot_output(highlight('library(a_list$pkg)'))
+
+})
+


### PR DESCRIPTION
Seen when trying to highlight pkgdown's 

https://github.com/r-lib/pkgdown/blob/429aac8401b58b0275b76b045b569c28ad1287ba/R/build-reference.R#L218