### PR TITLE
allow call of library a la pkgdown

### DIFF
--- a/R/metadata.R
+++ b/R/metadata.R
@@ -88,6 +88,10 @@ fetch_yaml <- function(url) {
 # Helpers -----------------------------------------------------------------
 
 package_urls <- function(package) {
+  if (package == "") { # if e.g. library(a$pkg) then pkg is ""
+    return(character())
+  }
+
   path <- system.file("DESCRIPTION", package = package)
   if (path == "") {
     return(character())

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -4,6 +4,7 @@ test_that("can extract urls for package", {
 
   expect_equal(package_urls("base"), character())
   expect_equal(package_urls("packagethatdoesn'texist"), character())
+  expect_equal(package_urls(""), character())
   expect_equal(package_urls("MASS"), "http://www.stats.ox.ac.uk/pub/MASS4/")
 })
 


### PR DESCRIPTION
Seen when trying to highlight pkgdown's 

https://github.com/r-lib/pkgdown/blob/429aac8401b58b0275b76b045b569c28ad1287ba/R/build-reference.R#L218

Approach recommended in https://github.com/r-lib/downlit/pull/114#issuecomment-941329996