### PR TITLE
Add new R pipe support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Suggests:
     pkgload,
     rmarkdown,
     testthat (>= 3.0.0),
+    withr (>= 2.4.3),
     xml2
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,6 @@ Suggests:
     pkgload,
     rmarkdown,
     testthat (>= 3.0.0),
-    withr (>= 2.4.3),
     xml2
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,6 @@
 # downlit (development version)
 
-* New R pipe `|>` is now highlighted correctly as an infix operator like
-  magrittr's `%>%` (#126).
+* Adds support for new R pipe `|>` syntax (#126).
 
 # downlit 0.4.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # downlit (development version)
 
+* New R pipe `|>` is now highlighted correctly as an infix operator like
+  magrittr's `%>%` (#126).
+
 # downlit 0.4.0
 
 ## Syntax highlighting

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -204,6 +204,9 @@ token_type <- function(x, text) {
   x[x == "NULL_CONST"] <- "constant"
   x[x == "NULL_CONST"] <- "constant"
 
+  # Treats pipe's placeholder '_' as a SYMBOL
+  x[x == "PLACEHOLDER"] <- "SYMBOL"
+
   x
 }
 
@@ -231,7 +234,6 @@ classes_pandoc <- function() {
     "SLOT" = "va",
     "SYMBOL" = "va",
     "SYMBOL_FORMALS" = "va",
-    "PLACEHOLDER" = "va",
 
     "NS_GET" = "fu",
     "NS_GET_INT" = "fu",
@@ -258,7 +260,6 @@ classes_chroma <- function() {
     "SLOT" = "nv",
     "SYMBOL" = "nv",
     "SYMBOL_FORMALS" = "nv",
-    "PLACEHOLDER" = "nv",
 
     "NS_GET" = "nf",
     "NS_GET_INT" = "nf",

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -147,7 +147,7 @@ token_type <- function(x, text) {
   special <- c(
     "FUNCTION",
     "FOR", "IN", "BREAK", "NEXT", "REPEAT", "WHILE",
-    "IF", "ELSE"
+    "IF", "ELSE", "PLACEHOLDER"
   )
   rstudio_special <- c(
    "return", "switch", "try", "tryCatch", "stop",
@@ -170,7 +170,7 @@ token_type <- function(x, text) {
     # miscellaneous
     "'$'", "'@'","'~'", "'?'", "':'", "SPECIAL",
     # pipes
-    "PIPE", "PIPEBIND", "PLACEHOLDER"
+    "PIPE", "PIPEBIND"
   )
   x[x %in% infix] <- "infix"
 
@@ -184,6 +184,7 @@ token_type <- function(x, text) {
   )
   x[x == "NUM_CONST" & text %in% constant] <- "constant"
   x[x == "SYMBOL" & text %in% c("T", "F")] <- "constant"
+  x[x == "NULL_CONST"] <- "constant"
   x[x == "NULL_CONST"] <- "constant"
 
   x

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -164,7 +164,7 @@ token_type <- function(x, text) {
   special <- c(
     "FUNCTION",
     "FOR", "IN", "BREAK", "NEXT", "REPEAT", "WHILE",
-    "IF", "ELSE", "PLACEHOLDER"
+    "IF", "ELSE"
   )
   rstudio_special <- c(
    "return", "switch", "try", "tryCatch", "stop",
@@ -231,6 +231,7 @@ classes_pandoc <- function() {
     "SLOT" = "va",
     "SYMBOL" = "va",
     "SYMBOL_FORMALS" = "va",
+    "PLACEHOLDER" = "va",
 
     "NS_GET" = "fu",
     "NS_GET_INT" = "fu",
@@ -257,6 +258,7 @@ classes_chroma <- function() {
     "SLOT" = "nv",
     "SYMBOL" = "nv",
     "SYMBOL_FORMALS" = "nv",
+    "PLACEHOLDER" = "nv",
 
     "NS_GET" = "nf",
     "NS_GET_INT" = "nf",

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -168,7 +168,9 @@ token_type <- function(x, text) {
     # assignment / equals
     "LEFT_ASSIGN", "RIGHT_ASSIGN", "EQ_ASSIGN", "EQ_FORMALS", "EQ_SUB",
     # miscellaneous
-    "'$'", "'@'","'~'", "'?'", "':'", "SPECIAL"
+    "'$'", "'@'","'~'", "'?'", "':'", "SPECIAL",
+    # pipes
+    "PIPE", "PIPEBIND"
   )
   x[x %in% infix] <- "infix"
 

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -170,7 +170,7 @@ token_type <- function(x, text) {
     # miscellaneous
     "'$'", "'@'","'~'", "'?'", "':'", "SPECIAL",
     # pipes
-    "PIPE", "PIPEBIND"
+    "PIPE", "PIPEBIND", "PLACEHOLDER"
   )
   x[x %in% infix] <- "infix"
 

--- a/tests/testthat/_snaps/highlight.md
+++ b/tests/testthat/_snaps/highlight.md
@@ -17,7 +17,7 @@
 # placeholder in R pipe gets highlighted and not linked
 
     Code
-      highlight("1:10 |> mean(x = _)")
+      highlight("1:10 |> mean(x = _)", classes = classes_pandoc())
     Output
-      [1] "<span class='m'>1</span><span class='o'>:</span><span class='m'>10</span> <span class='o'>|&gt;</span> <span class='nf'><a href='https://rdrr.io/r/base/mean.html'>mean</a></span><span class='o'>(</span>x <span class='o'>=</span> <span class='o'>_</span><span class='o'>)</span>"
+      [1] "<span class='fl'>1</span><span class='op'>:</span><span class='fl'>10</span> <span class='op'>|&gt;</span> <span class='fu'><a href='https://rdrr.io/r/base/mean.html'>mean</a></span><span class='op'>(</span>x <span class='op'>=</span> <span class='kw'>_</span><span class='op'>)</span>"
 

--- a/tests/testthat/_snaps/highlight.md
+++ b/tests/testthat/_snaps/highlight.md
@@ -14,3 +14,17 @@
 
     [1] "<span class='c'># <span style='color: #BB0000;'>hello</span></span>"
 
+# New R pipes get highlighted and not linked
+
+    Code
+      highlight("1 |> x => fun(2, x)")
+    Output
+      [1] "<span class='m'>1</span> <span class='o'>|&gt;</span> <span class='nv'>x</span> <span class='o'>=&gt;</span> <span class='nf'>fun</span><span class='o'>(</span><span class='m'>2</span>, <span class='nv'>x</span><span class='o'>)</span>"
+
+# placeholder in R pipe gets highlighted and not linked
+
+    Code
+      highlight("1:10 |> mean(x = _)")
+    Output
+      [1] "<span class='m'>1</span><span class='o'>:</span><span class='m'>10</span> <span class='o'>|&gt;</span> <span class='nf'><a href='https://rdrr.io/r/base/mean.html'>mean</a></span><span class='o'>(</span>x <span class='o'>=</span> <span class='o'>_</span><span class='o'>)</span>"
+

--- a/tests/testthat/_snaps/highlight.md
+++ b/tests/testthat/_snaps/highlight.md
@@ -14,13 +14,6 @@
 
     [1] "<span class='c'># <span style='color: #BB0000;'>hello</span></span>"
 
-# New R pipes get highlighted and not linked
-
-    Code
-      highlight("1 |> x => fun(2, x)")
-    Output
-      [1] "<span class='m'>1</span> <span class='o'>|&gt;</span> <span class='nv'>x</span> <span class='o'>=&gt;</span> <span class='nf'>fun</span><span class='o'>(</span><span class='m'>2</span>, <span class='nv'>x</span><span class='o'>)</span>"
-
 # placeholder in R pipe gets highlighted and not linked
 
     Code

--- a/tests/testthat/_snaps/highlight.md
+++ b/tests/testthat/_snaps/highlight.md
@@ -19,5 +19,5 @@
     Code
       highlight("1:10 |> mean(x = _)", classes = classes_pandoc())
     Output
-      [1] "<span class='fl'>1</span><span class='op'>:</span><span class='fl'>10</span> <span class='op'>|&gt;</span> <span class='fu'><a href='https://rdrr.io/r/base/mean.html'>mean</a></span><span class='op'>(</span>x <span class='op'>=</span> <span class='kw'>_</span><span class='op'>)</span>"
+      [1] "<span class='fl'>1</span><span class='op'>:</span><span class='fl'>10</span> <span class='op'>|&gt;</span> <span class='fu'><a href='https://rdrr.io/r/base/mean.html'>mean</a></span><span class='op'>(</span>x <span class='op'>=</span> <span class='va'>_</span><span class='op'>)</span>"
 

--- a/tests/testthat/test-highlight.R
+++ b/tests/testthat/test-highlight.R
@@ -110,12 +110,6 @@ test_that("ansi escapes are converted to html", {
   expect_snapshot_output(highlight("# \u2029[31mhello\u2029[m"))
 })
 
-test_that("New R pipes get highlighted and not linked", {
-  skip_if_not(getRversion() >= 4.1, message = "Pipes are available from R 4.1")
-  withr::local_envvar(list("_R_USE_PIPEBIND_" = TRUE))
-  expect_snapshot(highlight("1 |> x => fun(2, x)"))
-})
-
 test_that("placeholder in R pipe gets highlighted and not linked", {
   skip_if_not(getRversion() >= 4.2, message = "Pipes are available from R 4.1")
   expect_snapshot(highlight("1:10 |> mean(x = _)"))

--- a/tests/testthat/test-highlight.R
+++ b/tests/testthat/test-highlight.R
@@ -112,5 +112,5 @@ test_that("ansi escapes are converted to html", {
 
 test_that("placeholder in R pipe gets highlighted and not linked", {
   skip_if_not(getRversion() >= 4.2, message = "Pipes are available from R 4.1")
-  expect_snapshot(highlight("1:10 |> mean(x = _)"))
+  expect_snapshot(highlight("1:10 |> mean(x = _)", classes = classes_pandoc()))
 })

--- a/tests/testthat/test-highlight.R
+++ b/tests/testthat/test-highlight.R
@@ -113,16 +113,10 @@ test_that("ansi escapes are converted to html", {
 test_that("New R pipes get highlighted and not linked", {
   skip_if_not(getRversion() >= 4.1, message = "Pipes are available from R 4.1")
   withr::local_envvar(list("_R_USE_PIPEBIND_" = TRUE))
-  expect_equal(
-    highlight("1 |> x => fun(2, x)"),
-    "<span class='m'>1</span> <span class='o'>|&gt;</span> <span class='nv'>x</span> <span class='o'>=&gt;</span> <span class='nf'>fun</span><span class='o'>(</span><span class='m'>2</span>, <span class='nv'>x</span><span class='o'>)</span>"
-  )
+  expect_snapshot(highlight("1 |> x => fun(2, x)"))
 })
 
 test_that("placeholder in R pipe gets highlighted and not linked", {
   skip_if_not(getRversion() >= 4.2, message = "Pipes are available from R 4.1")
-  expect_equal(
-    highlight("1:10 |> mean(x = _)"),
-    "<span class='m'>1</span><span class='o'>:</span><span class='m'>10</span> <span class='o'>|&gt;</span> <span class='nf'><a href='https://rdrr.io/r/base/mean.html'>mean</a></span><span class='o'>(</span>x <span class='o'>=</span> <span class='o'>_</span><span class='o'>)</span>"
-  )
+  expect_snapshot(highlight("1:10 |> mean(x = _)"))
 })

--- a/tests/testthat/test-highlight.R
+++ b/tests/testthat/test-highlight.R
@@ -111,10 +111,18 @@ test_that("ansi escapes are converted to html", {
 })
 
 test_that("New R pipes get highlighted and not linked", {
-  skip_if_not(getRversion() > 4.1, message = "Pipes are available from R 4.1")
+  skip_if_not(getRversion() >= 4.1, message = "Pipes are available from R 4.1")
   withr::local_envvar(list("_R_USE_PIPEBIND_" = TRUE))
   expect_equal(
     highlight("1 |> x => fun(2, x)"),
     "<span class='m'>1</span> <span class='o'>|&gt;</span> <span class='nv'>x</span> <span class='o'>=&gt;</span> <span class='nf'>fun</span><span class='o'>(</span><span class='m'>2</span>, <span class='nv'>x</span><span class='o'>)</span>"
+  )
+})
+
+test_that("placeholder in R pipe gets highlighted and not linked", {
+  skip_if_not(getRversion() >= 4.2, message = "Pipes are available from R 4.1")
+  expect_equal(
+    highlight("1:10 |> mean(x = _)"),
+    "<span class='m'>1</span><span class='o'>:</span><span class='m'>10</span> <span class='o'>|&gt;</span> <span class='nf'><a href='https://rdrr.io/r/base/mean.html'>mean</a></span><span class='o'>(</span>x <span class='o'>=</span> <span class='o'>_</span><span class='o'>)</span>"
   )
 })

--- a/tests/testthat/test-highlight.R
+++ b/tests/testthat/test-highlight.R
@@ -109,3 +109,16 @@ test_that("ansi escapes are converted to html", {
   expect_snapshot_output(highlight("# \033[31mhello\033[m"))
   expect_snapshot_output(highlight("# \u2029[31mhello\u2029[m"))
 })
+
+test_that("New R pipes get highlighted and not linked", {
+  skip_if_not(getRversion() > 4.1, message = "Pipes are available from R 4.1")
+  expect_equal(
+    highlight("1 |> fun()"),
+    "<span class='m'>1</span> <span class='o'>|&gt;</span> <span class='nf'>fun</span><span class='o'>(</span><span class='o'>)</span>"
+  )
+  withr::local_envvar(list("_R_USE_PIPEBIND_" = TRUE))
+  expect_equal(
+    highlight("x => fun(2, x)"),
+    "<span class='nv'>x</span> <span class='o'>=&gt;</span> <span class='nf'>fun</span><span class='o'>(</span><span class='m'>2</span>, <span class='nv'>x</span><span class='o'>)</span>"
+  )
+})

--- a/tests/testthat/test-highlight.R
+++ b/tests/testthat/test-highlight.R
@@ -112,13 +112,9 @@ test_that("ansi escapes are converted to html", {
 
 test_that("New R pipes get highlighted and not linked", {
   skip_if_not(getRversion() > 4.1, message = "Pipes are available from R 4.1")
-  expect_equal(
-    highlight("1 |> fun()"),
-    "<span class='m'>1</span> <span class='o'>|&gt;</span> <span class='nf'>fun</span><span class='o'>(</span><span class='o'>)</span>"
-  )
   withr::local_envvar(list("_R_USE_PIPEBIND_" = TRUE))
   expect_equal(
-    highlight("x => fun(2, x)"),
-    "<span class='nv'>x</span> <span class='o'>=&gt;</span> <span class='nf'>fun</span><span class='o'>(</span><span class='m'>2</span>, <span class='nv'>x</span><span class='o'>)</span>"
+    highlight("1 |> x => fun(2, x)"),
+    "<span class='m'>1</span> <span class='o'>|&gt;</span> <span class='nv'>x</span> <span class='o'>=&gt;</span> <span class='nf'>fun</span><span class='o'>(</span><span class='m'>2</span>, <span class='nv'>x</span><span class='o'>)</span>"
   )
 })


### PR DESCRIPTION
This PR closes #126 

Parsing shows that token are `PIPE` and `PIPEBIND`

``` r
Sys.setenv("_R_USE_PIPEBIND_"= TRUE)
downlit:::parse_data("1 |> x => fun(2, x)")
#> $text
#> [1] "1 |> x => fun(2, x)"
#> 
#> $expr
#> expression(1 |> x => fun(2, x))
#> 
#> $data
#>    line1 col1 line2 col2 id parent                token terminal text
#> 25     1    1     1   19 25      0                 expr    FALSE     
#> 1      1    1     1    1  1      2            NUM_CONST     TRUE    1
#> 2      1    1     1    1  2     25                 expr    FALSE     
#> 3      1    3     1    4  3     25                 PIPE     TRUE   |>
#> 24     1    6     1   19 24     25                 expr    FALSE     
#> 4      1    6     1    6  4      6               SYMBOL     TRUE    x
#> 6      1    6     1    6  6     24                 expr    FALSE     
#> 5      1    8     1    9  5     24             PIPEBIND     TRUE   =>
#> 22     1   11     1   19 22     24                 expr    FALSE     
#> 7      1   11     1   13  7      9 SYMBOL_FUNCTION_CALL     TRUE  fun
#> 9      1   11     1   13  9     22                 expr    FALSE     
#> 8      1   14     1   14  8     22                  '('     TRUE    (
#> 10     1   15     1   15 10     11            NUM_CONST     TRUE    2
#> 11     1   15     1   15 11     22                 expr    FALSE     
#> 12     1   16     1   16 12     22                  ','     TRUE    ,
#> 16     1   18     1   18 16     18               SYMBOL     TRUE    x
#> 18     1   18     1   18 18     22                 expr    FALSE     
#> 17     1   19     1   19 17     22                  ')'     TRUE    )
```

I have put them in the `infix` category with the magrittr pipe. 

For new placeholder we have `PLACEHOLDER` token
``` r
downlit:::parse_data("1:10 |> mean(x = _)")
#> $text
#> [1] "1:10 |> mean(x = _)"
#> 
#> $expr
#> expression(1:10 |> mean(x = _))
#> 
#> $data
#>    line1 col1 line2 col2 id parent                token terminal text
#> 21     1    1     1   19 21      0                 expr    FALSE     
#> 7      1    1     1    4  7     21                 expr    FALSE     
#> 1      1    1     1    1  1      2            NUM_CONST     TRUE    1
#> 2      1    1     1    1  2      7                 expr    FALSE     
#> 3      1    2     1    2  3      7                  ':'     TRUE    :
#> 4      1    3     1    4  4      5            NUM_CONST     TRUE   10
#> 5      1    3     1    4  5      7                 expr    FALSE     
#> 6      1    6     1    7  6     21                 PIPE     TRUE   |>
#> 19     1    9     1   19 19     21                 expr    FALSE     
#> 8      1    9     1   12  8     10 SYMBOL_FUNCTION_CALL     TRUE mean
#> 10     1    9     1   12 10     19                 expr    FALSE     
#> 9      1   13     1   13  9     19                  '('     TRUE    (
#> 11     1   14     1   14 11     19           SYMBOL_SUB     TRUE    x
#> 12     1   16     1   16 12     19               EQ_SUB     TRUE    =
#> 13     1   18     1   18 13     14          PLACEHOLDER     TRUE    _
#> 14     1   18     1   18 14     19                 expr    FALSE     
#> 15     1   19     1   19 15     19                  ')'     TRUE    )
```

Not sure which highlight class it should have. Proposal in operator too for this one.

Added tests dependent on R requirement. Snapshots seems ok to use here.