### PR TITLE
remove unused utilities

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,28 +1,3 @@
-is_infix <- function(x) {
-  ops <- c(
-    "::", ":::", "$", "@", "[", "[[", "^", "-", "+", ":", "*", "/",
-    "<", ">", "<=", ">=", "==", "!=", "!", "&", "&&", "|", "||", "~",
-    "->", "->>", "<-", "<<-", "=", "?"
-  )
-
-  grepl("^%.*%$", x) || x %in% ops
-}
-
-is_prefix <- function(x) {
-  if (is_infix(x)) {
-    return(FALSE)
-  }
-
-  special <- c(
-    "(", "{", "if", "for", "while", "repeat", "next", "break", "function"
-  )
-  if (x %in% special) {
-    return(FALSE)
-  }
-
-  TRUE
-}
-
 devtools_loaded <- function(x) {
   if (!x %in% loadedNamespaces()) {
     return(FALSE)


### PR DESCRIPTION
Before `0.4.0` release:
- `is_infix()` was used in `autolink_url()` and `href_expr()`
- `is_prefix()` was used in `href_expr()`

But refactoring in `0.4.0` release removed this reliance, and they are no longer used anywhere in the package.