### PR TITLE
Fixes autolinking for double colon operator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # downlit (development version)
 
+* Auto-linking works when used with double colon infix operator 
+  (@IndrajeetPatil, #131).
+
 # downlit 0.4.0
 
 ## Syntax highlighting

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # downlit (development version)
 
-* Auto-linking works when used with double colon infix operator 
+* Auto-linking works when used with double colon infix operator and `utils::help()`
   (@IndrajeetPatil, #131).
 
 # downlit 0.4.0

--- a/R/link.R
+++ b/R/link.R
@@ -122,10 +122,10 @@ href_expr <- function(expr) {
     } else {
       NA_character_
     }
-  } else if (fun_name == "::") {
-    href_topic(as.character(expr[[3]]), as.character(expr[[2]]))
   } else if (n_args == 0) {
     href_topic(fun_name, pkg)
+  } else if (fun_name == "::") {
+    href_topic(as.character(expr[[3]]), as.character(expr[[2]]))
   } else {
     NA_character_
   }

--- a/R/link.R
+++ b/R/link.R
@@ -111,6 +111,8 @@ href_expr <- function(expr) {
       # package?x
       href_topic(paste0(expr[[3]], "-", expr[[2]]))
     }
+  } else if (n_args == 0) {
+    href_topic(fun_name, pkg)
   } else if (fun_name == "help") {
     expr <- call_standardise(expr)
     if (is_help_literal(expr$topic) && is_help_literal(expr$package)) {
@@ -122,8 +124,6 @@ href_expr <- function(expr) {
     } else {
       NA_character_
     }
-  } else if (n_args == 0) {
-    href_topic(fun_name, pkg)
   } else if (fun_name == "::") {
     href_topic(as.character(expr[[3]]), as.character(expr[[2]]))
   } else {

--- a/R/link.R
+++ b/R/link.R
@@ -71,7 +71,9 @@ href_expr <- function(expr) {
   fun_name <- as.character(fun)
   n_args <- length(expr) - 1
 
-  if (fun_name %in% c("library", "require", "requireNamespace")) {
+  if (n_args == 0) {
+    href_topic(fun_name, pkg)
+  } else if (fun_name %in% c("library", "require", "requireNamespace")) {
     if (n_args == 1 && is.null(names(expr))) {
       pkg <- as.character(expr[[2]])
       topic <- href_package(pkg)
@@ -83,10 +85,8 @@ href_expr <- function(expr) {
     } else {
       href_topic(fun_name)
     }
-  } else if (fun_name == "vignette") {
-    if (length(expr) == 1) {
-      return(href_topic(fun_name))
-    }
+  } else if (fun_name == "vignette" && n_args >= 1) {
+    # vignette("foo", "package")
     expr <- call_standardise(expr)
     topic_ok <- is.character(expr$topic)
     package_ok <- is.character(expr$package) || is.null(expr$package)
@@ -95,25 +95,21 @@ href_expr <- function(expr) {
     } else {
       NA_character_
     }
-  } else if (fun_name == "?") {
-    if (n_args == 1) {
-      topic <- expr[[2]]
-      if (is_call(topic, "::")) {
-        # ?pkg::x
-        href_topic(as.character(topic[[3]]), as.character(topic[[2]]))
-      } else if (is_symbol(topic) || is_string(topic)) {
-        # ?x
-        href_topic(as.character(expr[[2]]))
-      } else {
-        NA_character_
-      }
-    } else if (n_args == 2) {
-      # package?x
-      href_topic(paste0(expr[[3]], "-", expr[[2]]))
+  } else if (fun_name == "?" && n_args == 1) {
+    topic <- expr[[2]]
+    if (is_call(topic, "::")) {
+      # ?pkg::x
+      href_topic(as.character(topic[[3]]), as.character(topic[[2]]))
+    } else if (is_symbol(topic) || is_string(topic)) {
+      # ?x
+      href_topic(as.character(expr[[2]]))
+    } else {
+      NA_character_
     }
-  } else if (n_args == 0) {
-    href_topic(fun_name, pkg)
-  } else if (fun_name == "help") {
+  } else if (fun_name == "?" && n_args == 2) {
+    # package?x
+    href_topic(paste0(expr[[3]], "-", expr[[2]]))
+  } else if (fun_name == "help" && n_args >= 1) {
     expr <- call_standardise(expr)
     if (is_help_literal(expr$topic) && is_help_literal(expr$package)) {
       href_topic(as.character(expr$topic), as.character(expr$package))
@@ -124,7 +120,7 @@ href_expr <- function(expr) {
     } else {
       NA_character_
     }
-  } else if (fun_name == "::") {
+  } else if (fun_name == "::" && n_args == 2) {
     href_topic(as.character(expr[[3]]), as.character(expr[[2]]))
   } else {
     NA_character_

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -122,10 +122,10 @@ test_that("can link help calls", {
     "downlit.topic_index" = c(foo = "foo", "foo-package" = "foo-package")
   )
 
-  expect_equal(href_expr_(help()), "https://rdrr.io/r/utils/help.html")
   expect_equal(href_expr_(help("foo")), "foo.html")
   expect_equal(href_expr_(help("foo", "test")), "foo.html")
   expect_equal(href_expr_(help(package = "MASS")), "https://rdrr.io/pkg/MASS/man")
+  expect_equal(href_expr_(help()), "https://rdrr.io/r/utils/help.html")
   expect_equal(href_expr_(help(a$b)), NA_character_)
 })
 

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -130,6 +130,11 @@ test_that("can link ? calls", {
   expect_equal(href_expr_(package?foo), "foo-package.html")
 })
 
+test_that("can link help function in utils", {
+  expect_equal(href_expr_(help()), "https://rdrr.io/r/utils/help.html")
+  expect_equal(href_expr_(utils::help()), "https://rdrr.io/r/utils/help.html")
+})
+
 test_that("can link help calls", {
   local_options(
     "downlit.package" = "test",
@@ -139,7 +144,6 @@ test_that("can link help calls", {
   expect_equal(href_expr_(help("foo")), "foo.html")
   expect_equal(href_expr_(help("foo", "test")), "foo.html")
   expect_equal(href_expr_(help(package = "MASS")), "https://rdrr.io/pkg/MASS/man")
-  expect_equal(href_expr_(help()), NA_character_)
   expect_equal(href_expr_(help(a$b)), NA_character_)
 })
 

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -69,13 +69,15 @@ test_that("can link to functions in base packages", {
 
 test_that("can link to namespaced infix operators in base packages", {
   expect_equal(autolink_url("base::`::`()"), href_topic_remote("::", "base"))
-  expect_equal(autolink_url("base::`:::`()"), href_topic_remote(":::", "base"))
+  expect_equal(autolink_url("base::`::`('base', 'log')"), href_topic_remote("log", "base"))
   expect_equal(autolink_url("base::`::`()"), autolink_url("base::`:::`()"))
+  expect_equal(autolink_url("base::`:::`()"), href_topic_remote(":::", "base"))
   expect_equal(autolink_url("base::`+`()"), href_topic_remote("+", "base"))
 })
 
 test_that("can link to non-namespaced infix operators in base packages", {
   expect_equal(autolink_url("`::`()"), href_topic_remote("::", "base"))
+  expect_equal(autolink_url("`::`('base', 'log')"), href_topic_remote("log", "base"))
   expect_equal(autolink_url("`:::`()"), href_topic_remote(":::", "base"))
   expect_equal(autolink_url("`+`()"), href_topic_remote("+", "base"))
 })

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -38,6 +38,7 @@ test_that("can link remote objects", {
   expect_equal(href_expr_(MASS::abbey), href_topic_remote("abbey", "MASS"))
   expect_equal(href_expr_(MASS::addterm()), href_topic_remote("addterm", "MASS"))
   expect_equal(href_expr_(MASS::addterm.default()), href_topic_remote("addterm", "MASS"))
+  expect_equal(href_expr_(base::`::`), href_topic_remote("::", "base"))
 
   # Doesn't exist
   expect_equal(href_expr_(MASS::blah), NA_character_)
@@ -65,21 +66,6 @@ test_that("can link to package names in registered packages", {
 test_that("can link to functions in base packages", {
   expect_equal(href_expr_(abbreviate()), href_topic_remote("abbreviate", "base"))
   expect_equal(href_expr_(median()), href_topic_remote("median", "stats"))
-})
-
-test_that("can link to namespaced infix operators in base packages", {
-  expect_equal(autolink_url("base::`::`()"), href_topic_remote("::", "base"))
-  expect_equal(autolink_url("base::`::`('base', 'log')"), href_topic_remote("log", "base"))
-  expect_equal(autolink_url("base::`::`()"), autolink_url("base::`:::`()"))
-  expect_equal(autolink_url("base::`:::`()"), href_topic_remote(":::", "base"))
-  expect_equal(autolink_url("base::`+`()"), href_topic_remote("+", "base"))
-})
-
-test_that("can link to non-namespaced infix operators in base packages", {
-  expect_equal(autolink_url("`::`()"), href_topic_remote("::", "base"))
-  expect_equal(autolink_url("`::`('base', 'log')"), href_topic_remote("log", "base"))
-  expect_equal(autolink_url("`:::`()"), href_topic_remote(":::", "base"))
-  expect_equal(autolink_url("`+`()"), href_topic_remote("+", "base"))
 })
 
 test_that("links to home of re-exported functions", {
@@ -130,17 +116,13 @@ test_that("can link ? calls", {
   expect_equal(href_expr_(package?foo), "foo-package.html")
 })
 
-test_that("can link help function in utils", {
-  expect_equal(href_expr_(help()), "https://rdrr.io/r/utils/help.html")
-  expect_equal(href_expr_(utils::help()), "https://rdrr.io/r/utils/help.html")
-})
-
 test_that("can link help calls", {
   local_options(
     "downlit.package" = "test",
     "downlit.topic_index" = c(foo = "foo", "foo-package" = "foo-package")
   )
 
+  expect_equal(href_expr_(help()), "https://rdrr.io/r/utils/help.html")
   expect_equal(href_expr_(help("foo")), "foo.html")
   expect_equal(href_expr_(help("foo", "test")), "foo.html")
   expect_equal(href_expr_(help(package = "MASS")), "https://rdrr.io/pkg/MASS/man")

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -67,6 +67,13 @@ test_that("can link to functions in base packages", {
   expect_equal(href_expr_(median()), href_topic_remote("median", "stats"))
 })
 
+test_that("can link to infix operators in base packages", {
+  expect_equal(autolink_url("base::`::`()"), href_topic_remote("::", "base"))
+  expect_equal(autolink_url("base::`:::`()"), href_topic_remote(":::", "base"))
+  expect_equal(autolink_url("base::`::`()"), autolink_url("base::`:::`()"))
+  expect_equal(autolink_url("base::`+`()"), href_topic_remote("+", "base"))
+})
+
 test_that("links to home of re-exported functions", {
   expect_equal(href_expr_(testthat::`%>%`), href_topic_remote("%>%", "magrittr"))
 })

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -67,11 +67,17 @@ test_that("can link to functions in base packages", {
   expect_equal(href_expr_(median()), href_topic_remote("median", "stats"))
 })
 
-test_that("can link to infix operators in base packages", {
+test_that("can link to namespaced infix operators in base packages", {
   expect_equal(autolink_url("base::`::`()"), href_topic_remote("::", "base"))
   expect_equal(autolink_url("base::`:::`()"), href_topic_remote(":::", "base"))
   expect_equal(autolink_url("base::`::`()"), autolink_url("base::`:::`()"))
   expect_equal(autolink_url("base::`+`()"), href_topic_remote("+", "base"))
+})
+
+test_that("can link to non-namespaced infix operators in base packages", {
+  expect_equal(autolink_url("`::`()"), href_topic_remote("::", "base"))
+  expect_equal(autolink_url("`:::`()"), href_topic_remote(":::", "base"))
+  expect_equal(autolink_url("`+`()"), href_topic_remote("+", "base"))
 })
 
 test_that("links to home of re-exported functions", {


### PR DESCRIPTION
``base::`::`()`` tripped `href_expr()` because the function name is provided with `::` *and* no. of arguments is 0. 
This led the control flow in the wrong part of the conditionals. Reordering them does the trick!

# before

``` r
downlit::autolink_url("base::`::`()")
#> Error in expr[[2]]: subscript out of bounds
```

# after

``` r
downlit::autolink_url("base::`::`()")
#> [1] "https://rdrr.io/r/base/ns-dblcolon.html"
```

<sup>Created on 2022-03-13 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>

Closes #130 