### PR TITLE
Fixes truncation of long tokens by using utils::getParseText

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # downlit (development version)
 
+* Very long strings or other tokens are no longer truncated
+  by `downlit::highlight()` (@dmurdoch, #128).
+
 # downlit 0.4.0
 
 ## Syntax highlighting

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -130,7 +130,7 @@ getFullParseData <- function(x) {
 
   truncated <- res$terminal &
     substr(res$text, 1, 1) == "[" &
-    nchar(res$text) > 1
+    nchar(res$text) > 5  # 5 is arbitrary, 2 would probably be enough
 
   if (any(truncated))
     res$text[truncated] <- utils::getParseText(res, res$id[truncated])

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -133,7 +133,7 @@ getFullParseData <- function(x) {
     nchar(res$text) > 1
 
   if (any(truncated))
-    res[truncated, "text"] <- utils::getParseText(res, res$id[truncated])
+    res$text[truncated] <- utils::getParseText(res, res$id[truncated])
 
   res
 }

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -121,6 +121,23 @@ line_col <- function(x) {
   data.frame(line, col)
 }
 
+# utils::getParseData will truncate very long strings or tokens;
+# this function checks for that and uses the slow
+# utils::getParseText function when necessary.
+
+getFullParseData <- function(x) {
+  res <- utils::getParseData(x)
+
+  truncated <- res$terminal &
+    substr(res$text, 1, 1) == "[" &
+    nchar(res$text) > 1
+
+  if (any(truncated))
+    res[truncated, "text"] <- utils::getParseText(res, res$id[truncated])
+
+  res
+}
+
 parse_data <- function(text) {
   text <- standardise_text(text)
   stopifnot(is.character(text), length(text) == 1)
@@ -130,7 +147,7 @@ parse_data <- function(text) {
     return(NULL)
   }
 
-  list(text = text, expr = expr, data = utils::getParseData(expr))
+  list(text = text, expr = expr, data = getFullParseData(expr))
 }
 
 # Highlighting ------------------------------------------------------------

--- a/tests/testthat/test-highlight.R
+++ b/tests/testthat/test-highlight.R
@@ -109,3 +109,9 @@ test_that("ansi escapes are converted to html", {
   expect_snapshot_output(highlight("# \033[31mhello\033[m"))
   expect_snapshot_output(highlight("# \u2029[31mhello\u2029[m"))
 })
+
+test_that("can highlight vers long strings", {
+  val <- paste0(rep('very', 200), collapse = " ")
+  out <- downlit::highlight(sprintf("'%s'", val))
+  expect_equal(out, paste0("<span class='s'>'", val, "'</span>"))
+})


### PR DESCRIPTION
Fixes #128 .  This detects truncated strings by looking for a terminal token starting with "[" but longer; that's the pattern for the substitute `utils::getParseData()` uses, but not something the parser ever produces for real code.