### PR TITLE
href_topic() return NA if topic length > 1

### DIFF
--- a/R/link.R
+++ b/R/link.R
@@ -149,6 +149,9 @@ is_help_literal <- function(x) is_string(x) || is_symbol(x)
 #'
 #' href_package("downlit")
 href_topic <- function(topic, package = NULL) {
+  if (length(topic) != 1L) {
+    return(NA_character_)
+  }
   if (is_package_local(package)) {
     href_topic_local(topic)
   } else {

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -99,6 +99,7 @@ test_that("returns NA for bad inputs", {
   expect_equal(autolink_url(""), NA_character_)
   expect_equal(autolink_url("a; b"), NA_character_)
   expect_equal(autolink_url("1"), NA_character_)
+  expect_equal(autolink_url("ls *t??ne.pb"), NA_character_)
 })
 
 # help --------------------------------------------------------------------


### PR DESCRIPTION
If R interprets a BASH query with `?` and `*` wildcards as an R expression, then
it will parse it as help as shown in #137

This fixes #137 by exiting `href_topic()` if the length of the topic is
greater than 1
