### PR TITLE
Import withr, used by `CRAN_urls()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Imports:
     memoise,
     rlang,
     vctrs,
+    withr,
     yaml
 Suggests:
     covr,


### PR DESCRIPTION
My guess is that R CMD check doesn't find that you use withr because you memoise `CRAN_urls()` in the `.onLoad()`, which significantly changes the body of the function.