### PR TITLE
Fix: `downlit_html_*()` keeps all pre classes

### DIFF
--- a/R/downlit-html.R
+++ b/R/downlit-html.R
@@ -50,14 +50,14 @@ downlit_html_node <- function(x, classes = classes_pandoc()) {
     ".//div[contains(@class, 'downlit')]//pre"
   )
   xpath_block <- paste(xpath, collapse = "|")
-  pre_classes <- "downlit sourceCode r"
+  pre_classes <- c("downlit",  "sourceCode", "r")
   new_pre_classes <- xml2::xml_find_all(x, xpath_block)
 
   if (length(new_pre_classes) > 0) {
-    new_pre_classes <- xml2::xml_attr(new_pre_classes, "class")
-    new_pre_classes <- gsub("\\bsourceCode\\b|\\br\\b", "", new_pre_classes)
-    new_pre_classes <- trimws(new_pre_classes[!is.na(new_pre_classes)])
-    pre_classes <- paste(pre_classes, new_pre_classes)
+    new_pre_classes <- strsplit(xml2::xml_attr(new_pre_classes, "class"), " ")[[1]]
+    new_pre_classes <- new_pre_classes[!new_pre_classes %in% pre_classes]
+    new_pre_classes <- new_pre_classes[!is.na(new_pre_classes)]
+    pre_classes <- trimws(paste(unique(c(pre_classes, new_pre_classes))))
   }
 
   tweak_children(x, xpath_block, highlight,

--- a/R/downlit-html.R
+++ b/R/downlit-html.R
@@ -50,8 +50,18 @@ downlit_html_node <- function(x, classes = classes_pandoc()) {
     ".//div[contains(@class, 'downlit')]//pre"
   )
   xpath_block <- paste(xpath, collapse = "|")
+  pre_classes <- "downlit sourceCode r"
+  new_pre_classes <- xml2::xml_find_all(x, xpath_block)
+
+  if (length(new_pre_classes) > 0) {
+    new_pre_classes <- xml2::xml_attr(new_pre_classes, "class")
+    new_pre_classes <- gsub("\\bsourceCode\\b|\\br\\b", "", new_pre_classes)
+    new_pre_classes <- trimws(new_pre_classes[!is.na(new_pre_classes)])
+    pre_classes <- paste(pre_classes, new_pre_classes)
+  }
+
   tweak_children(x, xpath_block, highlight,
-    pre_class = "downlit sourceCode r",
+    pre_class = pre_classes,
     classes = classes,
     replace = "node",
     code = TRUE

--- a/tests/testthat/_snaps/downlit-html.md
+++ b/tests/testthat/_snaps/downlit-html.md
@@ -2,9 +2,9 @@
 
     <body>
       <div class="downlit">
-        <pre class="downlit sourceCode r">
+        <pre class="downlit sourceCode r ">
     <code class="sourceCode R"><span><span class="fl">1</span> <span class="op">+</span> <span class="fl">2</span></span></code></pre>
-        <pre class="downlit sourceCode r">
+        <pre class="downlit sourceCode r ">
     <code class="sourceCode R"><span><span class="fl">3</span> <span class="op">+</span> <span class="fl">4</span></span></code></pre>
       </div>
       <pre>No hightlight</pre>
@@ -17,4 +17,11 @@
 ---
 
     <p>before <code>{notapkg}</code> after</p>
+
+# keeps all pre classes
+
+    <div class="sourceCode">
+      <pre class="downlit sourceCode r my-class">
+    <code class="sourceCode R"><span><span class="va">Hello</span></span></code></pre>
+    </div>
 

--- a/tests/testthat/_snaps/downlit-html.md
+++ b/tests/testthat/_snaps/downlit-html.md
@@ -2,9 +2,9 @@
 
     <body>
       <div class="downlit">
-        <pre class="downlit sourceCode r ">
+        <pre class="downlit sourceCode r">
     <code class="sourceCode R"><span><span class="fl">1</span> <span class="op">+</span> <span class="fl">2</span></span></code></pre>
-        <pre class="downlit sourceCode r ">
+        <pre class="downlit sourceCode r">
     <code class="sourceCode R"><span><span class="fl">3</span> <span class="op">+</span> <span class="fl">4</span></span></code></pre>
       </div>
       <pre>No hightlight</pre>

--- a/tests/testthat/test-downlit-html.R
+++ b/tests/testthat/test-downlit-html.R
@@ -32,3 +32,17 @@ test_that("special package string gets linked", {
   downlit_html_node(html)
   expect_snapshot_output(show_xml(html))
 })
+
+test_that("keeps all pre classes", {
+  html <- xml2::read_xml("
+    <div class='sourceCode'>
+      <pre class='sourceCode r my-class'>
+        <code class='sourceCode r'>
+          <span>Hello</span>
+        </code>
+      </pre>
+    </div>"
+  )
+  downlit_html_node(html)
+  expect_snapshot_output(show_xml(html))
+})


### PR DESCRIPTION
Close #149, close #156. 

`downlit_html()` now keeps all `pre` classes, which allows for customization of code blocks in `pkgdown` using chunk options `class.source` and `attr.source`. 

Old behavior (`.my-class` is not kept):
``` r
html <- xml2::read_xml("
  <div class='sourceCode'>
    <pre class='sourceCode r my-class'>
      <code class='sourceCode r'>
        <span>Hello</span>
      </code>
    </pre>
  </div>"
)
downlit::downlit_html_node(html)
html
#> {xml_document}
#> <div class="sourceCode">
#> [1] <pre class="downlit sourceCode r">\n<code class="sourceCode R"><span><spa ...
```

<sup>Created on 2022-08-05 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

New behavior (`.my-class` is kept):
``` r
html <- xml2::read_xml("
  <div class='sourceCode'>
    <pre class='sourceCode r my-class'>
      <code class='sourceCode r'>
        <span>Hello</span>
      </code>
    </pre>
  </div>"
)
downlit::downlit_html_node(html)
html
#> {xml_document}
#> <div class="sourceCode">
#> [1] <pre class="downlit sourceCode r my-class">\n<code class="sourceCode R">< ...
```

<sup>Created on 2022-08-05 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

@cderv You said that a fix for this should also fix https://github.com/r-lib/downlit/issues/133 but I didn't look at https://github.com/r-lib/downlit/issues/133 because of time and because it is related to several other issues.

Happy to modify the code and to bump version and NEWS if required.