### PR TITLE
Expands meta-package support for tidymodels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # downlit (development version)
 
+* Expands meta-package support for tidymodels (#173).
+
 # downlit 0.4.3
 
 * Fix for upcoming R-devel (#169).

--- a/R/packages.R
+++ b/R/packages.R
@@ -34,10 +34,13 @@ register_attached_packages <- function(packages) {
   options("downlit.attached" = union(packages, getOption("downlit.attached")))
 }
 
+meta_packages <- c("tidyverse", "tidymodels")
 add_depends <- function(packages) {
-  if ("tidyverse" %in% packages && is_installed("tidyverse")) {
-    core <- getNamespace("tidyverse")$core
-    packages <- union(packages, core)
+  for (meta in meta_packages) {
+    if (meta %in% packages && is_installed(meta)) {
+      core <- getNamespace(meta)$core
+      packages <- union(packages, core)
+    }
   }
 
   # add packages attached by depends

--- a/tests/testthat/test-packages.R
+++ b/tests/testthat/test-packages.R
@@ -55,3 +55,8 @@ test_that("adds tidyverse packages", {
   skip_if_not_installed("tidyverse")
   expect_true("ggplot2" %in% add_depends("tidyverse"))
 })
+
+test_that("adds tidymodels packages", {
+  skip_if_not_installed("tidymodels")
+  expect_true("tune" %in% add_depends("tidymodels"))
+})


### PR DESCRIPTION
Closes #173 

@EmilHvitfeldt

``` r
downlit:::add_depends("tidymodels")
#>  [1] "tidymodels"   "broom"        "dials"        "dplyr"        "ggplot2"     
#>  [6] "infer"        "modeldata"    "parsnip"      "purrr"        "recipes"     
#> [11] "rsample"      "tibble"       "tidyr"        "tune"         "workflows"   
#> [16] "workflowsets" "yardstick"    "scales"
```

<sup>Created on 2024-01-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>